### PR TITLE
Install extras script

### DIFF
--- a/NickvisionApplication.GNOME/install_extras.sh
+++ b/NickvisionApplication.GNOME/install_extras.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+INSTALL_PREFIX="/usr"
+if [ ! -z $1 ]
+then
+	INSTALL_PREFIX=$1
+fi
+echo Install prefix: $INSTALL_PREFIX
+
+SOURCE_PREFIX="."
+if [ ${PWD##*/} == "NickvisionApplication.GNOME" ]
+then
+	SOURCE_PREFIX=".."
+fi
+
+echo Installing icons...
+mkdir -p $INSTALL_PREFIX/share/icons/hicolor/scalable/apps
+cp $SOURCE_PREFIX/NickvisionApplication.Shared/Resources/org.nickvision.application.svg $INSTALL_PREFIX/share/icons/hicolor/scalable/apps/
+cp $SOURCE_PREFIX/NickvisionApplication.Shared/Resources/org.nickvision.application-devel.svg $INSTALL_PREFIX/share/icons/hicolor/scalable/apps/
+mkdir -p $INSTALL_PREFIX/share/icons/hicolor/symbolic/apps
+cp $SOURCE_PREFIX/NickvisionApplication.Shared/Resources/org.nickvision.application-symbolic.svg $INSTALL_PREFIX/share/icons/hicolor/symbolic/apps/
+
+#echo Installing GResource...
+#mkdir -p $INSTALL_PREFIX/share/org.nickvision.application
+#glib-compile-resources $SOURCE_PREFIX/NickvisionApplication.GNOME/Resources/org.nickvision.application.gresource.xml
+#mv $SOURCE_PREFIX/NickvisionApplication.GNOME/Resources/org.nickvision.application.gresource $INSTALL_PREFIX/share/org.nickvision.application/
+
+echo Installing desktop file...
+mkdir -p $INSTALL_PREFIX/share/applications
+cp $SOURCE_PREFIX/NickvisionApplication.GNOME/org.nickvision.application.desktop $INSTALL_PREFIX/share/applications/
+
+echo Installing metainfo...
+mkdir -p $INSTALL_PREFIX/share/metainfo
+cp $SOURCE_PREFIX/NickvisionApplication.GNOME/org.nickvision.application.metainfo.xml $INSTALL_PREFIX/share/metainfo/
+
+echo Done!

--- a/NickvisionApplication.GNOME/org.nickvision.application-gnomebuilder.json
+++ b/NickvisionApplication.GNOME/org.nickvision.application-gnomebuilder.json
@@ -34,15 +34,7 @@
             "build-commands": [
                 "mkdir -p /app/opt/org.nickvision.application",
                 "dotnet publish NickvisionApplication.GNOME --self-contained true -o /app/opt/org.nickvision.application",
-                "mkdir -p /app/share/icons/hicolor/scalable/apps",
-                "cp NickvisionApplication.Shared/Resources/org.nickvision.application.svg /app/share/icons/hicolor/scalable/apps/",
-                "cp NickvisionApplication.Shared/Resources/org.nickvision.application-devel.svg /app/share/icons/hicolor/scalable/apps/",
-                "mkdir -p /app/share/icons/hicolor/symbolic/apps",
-                "cp NickvisionApplication.Shared/Resources/org.nickvision.application-symbolic.svg /app/share/icons/hicolor/symbolic/apps/",
-                "mkdir -p /app/share/applications",
-                "cp NickvisionApplication.GNOME/org.nickvision.application.desktop /app/share/applications/",
-                "mkdir -p /app/share/metainfo",
-                "cp NickvisionApplication.GNOME/org.nickvision.application.metainfo.xml /app/share/metainfo/"
+                "NickvisionApplication.GNOME/install_extras.sh /app"
             ],
             "sources": [
                 {

--- a/NickvisionApplication.GNOME/org.nickvision.application.json
+++ b/NickvisionApplication.GNOME/org.nickvision.application.json
@@ -54,15 +54,7 @@
                 "dotnet publish -c Release --source ./nuget-sources NickvisionApplication.GNOME/NickvisionApplication.GNOME.csproj --runtime $RUNTIME --self-contained true",
                 "mkdir -p /app/opt/org.nickvision.application",
                 "cp -r --remove-destination /run/build/org.nickvision.application/NickvisionApplication.GNOME/bin/Release/net7.0/$RUNTIME/publish/* /app/opt/org.nickvision.application/",
-                "mkdir -p /app/share/icons/hicolor/scalable/apps",
-                "cp NickvisionApplication.Shared/Resources/org.nickvision.application.svg /app/share/icons/hicolor/scalable/apps/",
-                "cp NickvisionApplication.Shared/Resources/org.nickvision.application-devel.svg /app/share/icons/hicolor/scalable/apps/",
-                "mkdir -p /app/share/icons/hicolor/symbolic/apps",
-                "cp NickvisionApplication.Shared/Resources/org.nickvision.application-symbolic.svg /app/share/icons/hicolor/symbolic/apps/",
-                "mkdir -p /app/share/applications",
-                "cp NickvisionApplication.GNOME/org.nickvision.application.desktop /app/share/applications/",
-                "mkdir -p /app/share/metainfo",
-                "cp NickvisionApplication.GNOME/org.nickvision.application.metainfo.xml /app/share/metainfo/"
+                "NickvisionApplication.GNOME/install_extras.sh /app"
 	    ],
             "sources": [
                 "sources.json",


### PR DESCRIPTION
I decided to move installing extra files to the separate script. It executes all the same commands that were in manifests, but now it's easier to repackage the app. For example, AUR package could contain something like this:
```
dotnet blahblahblah
cd NickvisionApplication.GNOME
./install_extras.sh $BUILDDIR
```

There's also commented strings to install *.gresource. The Application doesn't have it, but Money does and other apps might have it too, so I kept commands.