### PR TITLE
Add EditorConfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+[*.{sln,resx}]
+indent_style = tab
+
+[*.{cs,sh,py,json}]
+indent_style = space
+indent_size = 4
+
+[*.{csproj,xml,css,md}]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
[EditorConfig](https://editorconfig.org/) is a file that sets coding style rules for a projects and IDE can follow them, overwriting user settings. GNOME Builder supports it out of the box, VS Code requires an extension.
This is useful because Builder uses tabs for `.cs` files by default for example, so EditorConfig will help keep all files to use indents that we already use. EditorConfig can be used to set some other rules, but I only set indents according to what we use in Application, Denaro and Tube Converter. Although TC breaks the rule with `.csproj` files: tabs are used there. Also translated `.resx` files have mixed indents, but this should not be a problem since we use Weblate anyway, it only matters for original `Strings.resx`.